### PR TITLE
Add word counter utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ gem install fast-stemmer lemmatizer stopwords
 
 The script removes dialogue enclosed in straight or curly double quotes before
 counting words so quoted speech is ignored. Trailing possessive `'s` is
-collapsed so words like `Lucy` and `Lucy's` are tallied together. A few extra
-contractions such as `didn't` and `couldn't` are added to the default stop word
-list provided by the `stopwords` gem.
+collapsed so words like `Lucy` and `Lucy's` are tallied together. Extra stop
+words like `this`, `i`, `as`, `that`, `his`, `they`, `did`, `could`, `didn't`,
+and `couldn't` are merged with the gem's default list. Their stems are
+precomputed so conjugated forms such as `did` (which lemmatizes to `do`) are
+still matched.

--- a/README.md
+++ b/README.md
@@ -18,10 +18,11 @@ gem install fast-stemmer lemmatizer stopwords optimist
 ```
 
 You can include stop words in the output with `-s` and redirect the results to
-a file with `-o`:
+a file with `-o`. By default only repeated words are printed; pass
+`--no-repeat-only` to show every word:
 
 ```bash
-./word_counter.rb -s -o results.txt sample.md
+./word_counter.rb -s -o results.txt --no-repeat-only sample.md
 ```
 
 The script removes dialogue enclosed in straight or curly double quotes before

--- a/README.md
+++ b/README.md
@@ -3,10 +3,11 @@
 ## Setup
 
 These scripts rely on a few Ruby gems. To run `word_counter.rb`, install the
-`fast-stemmer` and `lemmatizer` gems:
+`fast-stemmer`, `lemmatizer`, and `stopwords` gems. The `stopwords` gem
+provides a dictionary of common English stop words used by the script:
 
 ```bash
-gem install fast-stemmer lemmatizer
+gem install fast-stemmer lemmatizer stopwords
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@ a file with `-o`. By default only repeated words are printed; pass
 
  The script strips dialogue enclosed in straight, curly, or angle double quotes
 using a quote-aware scanner so longer files with uneven quoting are handled
- correctly.
+ correctly. See `sample_quotes.md` for examples including single-quoted,
+angle-quoted, and curly-quoted dialogue.
 Trailing possessive `'s` is collapsed so words like `Lucy` and `Lucy's` are
 tallied together. Extra stop words like `this`, `i`, `as`, `that`, `his`,
 `they`, `did`, `could`, `didn't`, and `couldn't` are merged with the gem's

--- a/README.md
+++ b/README.md
@@ -17,4 +17,7 @@ gem install fast-stemmer lemmatizer stopwords
 ```
 
 The script removes dialogue enclosed in straight or curly double quotes before
-counting words so quoted speech is ignored.
+counting words so quoted speech is ignored. Trailing possessive `'s` is
+collapsed so words like `Lucy` and `Lucy's` are tallied together. A few extra
+contractions such as `didn't` and `couldn't` are added to the default stop word
+list provided by the `stopwords` gem.

--- a/README.md
+++ b/README.md
@@ -25,10 +25,10 @@ a file with `-o`. By default only repeated words are printed; pass
 ./word_counter.rb -s -o results.txt --no-repeat-only sample.md
 ```
 
-The script removes dialogue enclosed in straight or curly double quotes before
-counting words so quoted speech is ignored. Trailing possessive `'s` is
-collapsed so words like `Lucy` and `Lucy's` are tallied together. Extra stop
-words like `this`, `i`, `as`, `that`, `his`, `they`, `did`, `could`, `didn't`,
-and `couldn't` are merged with the gem's default list. Their stems are
-precomputed so conjugated forms such as `did` (which lemmatizes to `do`) are
-still matched.
+The script strips dialogue enclosed in straight or curly double quotes using a
+quote-aware scanner so longer files with uneven quoting are handled correctly.
+Trailing possessive `'s` is collapsed so words like `Lucy` and `Lucy's` are
+tallied together. Extra stop words like `this`, `i`, `as`, `that`, `his`,
+`they`, `did`, `could`, `didn't`, and `couldn't` are merged with the gem's
+default list. Their stems are precomputed so conjugated forms such as `did`
+(which lemmatizes to `do`) are still matched.

--- a/README.md
+++ b/README.md
@@ -25,9 +25,10 @@ a file with `-o`. By default only repeated words are printed; pass
 ./word_counter.rb -s -o results.txt --no-repeat-only sample.md
 ```
 
-The script strips dialogue enclosed in straight, curly, or angle double quotes
-using a quote-aware scanner so longer files with uneven quoting are handled
-correctly.
+ The script strips dialogue enclosed in straight, curly, or angle double quotes
+as well as passages wrapped in single quotes when they act as dialogue.
+It uses a quote-aware scanner so longer files with uneven quoting are handled
+ correctly.
 Trailing possessive `'s` is collapsed so words like `Lucy` and `Lucy's` are
 tallied together. Extra stop words like `this`, `i`, `as`, `that`, `his`,
 `they`, `did`, `could`, `didn't`, and `couldn't` are merged with the gem's

--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 ## Setup
 
-These scripts rely on a few Ruby gems. To run `word_counter.rb`, you need the
-`fast-stemmer` gem installed:
+These scripts rely on a few Ruby gems. To run `word_counter.rb`, install the
+`fast-stemmer` and `lemmatizer` gems:
 
 ```bash
-gem install fast-stemmer
+gem install fast-stemmer lemmatizer
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -15,3 +15,6 @@ gem install fast-stemmer lemmatizer stopwords
 ```bash
 ./word_counter.rb sample.md
 ```
+
+The script removes dialogue enclosed in straight or curly double quotes before
+counting words so quoted speech is ignored.

--- a/README.md
+++ b/README.md
@@ -25,10 +25,11 @@ a file with `-o`. By default only repeated words are printed; pass
 ./word_counter.rb -s -o results.txt --no-repeat-only sample.md
 ```
 
- The script strips dialogue enclosed in straight, curly, or angle double quotes
-using a quote-aware scanner so longer files with uneven quoting are handled
- correctly. See `sample_quotes.md` for examples including single-quoted,
-angle-quoted, and curly-quoted dialogue.
+ The script strips dialogue before counting words. It first removes text
+ enclosed in curly double quotes (`“...”`) and then runs a quote-aware scanner
+ to drop any remaining straight or angle double quoted passages. See
+ `sample_quotes.md` for examples including single-quoted, angle-quoted, and
+ curly-quoted dialogue.
 Trailing possessive `'s` is collapsed so words like `Lucy` and `Lucy's` are
 tallied together. Extra stop words like `this`, `i`, `as`, `that`, `his`,
 `they`, `did`, `could`, `didn't`, and `couldn't` are merged with the gem's

--- a/README.md
+++ b/README.md
@@ -3,17 +3,25 @@
 ## Setup
 
 These scripts rely on a few Ruby gems. To run `word_counter.rb`, install the
-`fast-stemmer`, `lemmatizer`, and `stopwords` gems. The `stopwords` gem
-provides a dictionary of common English stop words used by the script:
+`fast-stemmer`, `lemmatizer`, `stopwords`, and `optimist` gems. The
+`stopwords` gem provides a dictionary of common English stop words used by the
+script and `optimist` supplies easy option parsing:
 
 ```bash
-gem install fast-stemmer lemmatizer stopwords
+gem install fast-stemmer lemmatizer stopwords optimist
 ```
 
 ## Usage
 
 ```bash
 ./word_counter.rb sample.md
+```
+
+You can include stop words in the output with `-s` and redirect the results to
+a file with `-o`:
+
+```bash
+./word_counter.rb -s -o results.txt sample.md
 ```
 
 The script removes dialogue enclosed in straight or curly double quotes before

--- a/README.md
+++ b/README.md
@@ -1,0 +1,16 @@
+# Scripts
+
+## Setup
+
+These scripts rely on a few Ruby gems. To run `word_counter.rb`, you need the
+`fast-stemmer` gem installed:
+
+```bash
+gem install fast-stemmer
+```
+
+## Usage
+
+```bash
+./word_counter.rb sample.md
+```

--- a/README.md
+++ b/README.md
@@ -17,12 +17,14 @@ gem install fast-stemmer lemmatizer stopwords optimist
 ./word_counter.rb sample.md
 ```
 
-You can include stop words in the output with `-s` and redirect the results to
-a file with `-o`. By default only repeated words are printed; pass
-`--no-repeat-only` to show every word:
+You can include stop words in the output with `-s`, keep particular stop words
+from being filtered using `-k word1,word2`, and redirect results to a file with
+`-o`. By default only repeated words are printed; pass `--no-repeat-only` to
+show every word:
 
 ```bash
 ./word_counter.rb -s -o results.txt --no-repeat-only sample.md
+./word_counter.rb -k still sample.md
 ```
 
  The script strips dialogue before counting words. It first removes text
@@ -35,3 +37,5 @@ tallied together. Extra stop words like `this`, `i`, `as`, `that`, `his`,
 `they`, `did`, `could`, `didn't`, and `couldn't` are merged with the gem's
 default list. Their stems are precomputed so conjugated forms such as `did`
 (which lemmatizes to `do`) are still matched.
+Pass `-k still` or another comma-separated list to keep particular stop words in
+the main output.

--- a/README.md
+++ b/README.md
@@ -25,8 +25,9 @@ a file with `-o`. By default only repeated words are printed; pass
 ./word_counter.rb -s -o results.txt --no-repeat-only sample.md
 ```
 
-The script strips dialogue enclosed in straight or curly double quotes using a
-quote-aware scanner so longer files with uneven quoting are handled correctly.
+The script strips dialogue enclosed in straight, curly, or angle double quotes
+using a quote-aware scanner so longer files with uneven quoting are handled
+correctly.
 Trailing possessive `'s` is collapsed so words like `Lucy` and `Lucy's` are
 tallied together. Extra stop words like `this`, `i`, `as`, `that`, `his`,
 `they`, `did`, `could`, `didn't`, and `couldn't` are merged with the gem's

--- a/README.md
+++ b/README.md
@@ -26,8 +26,7 @@ a file with `-o`. By default only repeated words are printed; pass
 ```
 
  The script strips dialogue enclosed in straight, curly, or angle double quotes
-as well as passages wrapped in single quotes when they act as dialogue.
-It uses a quote-aware scanner so longer files with uneven quoting are handled
+using a quote-aware scanner so longer files with uneven quoting are handled
  correctly.
 Trailing possessive `'s` is collapsed so words like `Lucy` and `Lucy's` are
 tallied together. Extra stop words like `this`, `i`, `as`, `that`, `his`,

--- a/README.md
+++ b/README.md
@@ -17,15 +17,24 @@ gem install fast-stemmer lemmatizer stopwords optimist
 ./word_counter.rb sample.md
 ```
 
-You can include stop words in the output with `-s`, keep particular stop words
-from being filtered using `-k word1,word2`, and redirect results to a file with
-`-o`. By default only repeated words are printed; pass `--no-repeat-only` to
-show every word:
+You can include stop words in the output with `-s` and redirect results to a
+file with `-o`. By default only repeated words are printed; pass
+`--no-repeat-only` to show every word:
 
 ```bash
 ./word_counter.rb -s -o results.txt --no-repeat-only sample.md
-./word_counter.rb -k still sample.md
 ```
+
+To keep particular stop words instead of filtering them, create a
+`word_counter.yml` file next to the script and list them under
+`keep_stop_words`:
+
+```yaml
+keep_stop_words:
+  - still
+```
+
+The script loads this configuration automatically if the file exists.
 
  The script strips dialogue before counting words. It first removes text
  enclosed in curly double quotes (`“...”`) and then runs a quote-aware scanner
@@ -36,6 +45,5 @@ Trailing possessive `'s` is collapsed so words like `Lucy` and `Lucy's` are
 tallied together. Extra stop words like `this`, `i`, `as`, `that`, `his`,
 `they`, `did`, `could`, `didn't`, and `couldn't` are merged with the gem's
 default list. Their stems are precomputed so conjugated forms such as `did`
-(which lemmatizes to `do`) are still matched.
-Pass `-k still` or another comma-separated list to keep particular stop words in
-the main output.
+(which lemmatizes to `do`) are still matched. List any stop words you want to
+keep under `keep_stop_words` in `word_counter.yml`.

--- a/sample.md
+++ b/sample.md
@@ -1,0 +1,1 @@
+She gestured at the sign. "See that sign she made?" and signed something on the table, with a gesture.

--- a/sample.md
+++ b/sample.md
@@ -1,1 +1,2 @@
 She gestured at the sign. "See that sign she made?" and signed something on the table, with a gesture.
+Still she waited. The sign was still visible.

--- a/sample_quotes.md
+++ b/sample_quotes.md
@@ -2,3 +2,4 @@ He opened the door. "Come in," she said.
 Then she whispered, "Stay\nquiet." The man nodded.
 «I won't stay long,» he replied.
 She muttered, "And so I said, 'you're crazy. I didn't mean that'. and she'd yelled back."
+Tom looked at him. “She’s got a point. We’re not used to functional Ben.” He nodded.

--- a/sample_quotes.md
+++ b/sample_quotes.md
@@ -1,2 +1,3 @@
 He opened the door. "Come in," she said.
 Then she whispered, "Stay\nquiet." The man nodded.
+«I won't stay long,» he replied.

--- a/sample_quotes.md
+++ b/sample_quotes.md
@@ -1,3 +1,4 @@
 He opened the door. "Come in," she said.
 Then she whispered, "Stay\nquiet." The man nodded.
 «I won't stay long,» he replied.
+She muttered, 'you're crazy. I didn't mean that.' Then left.

--- a/sample_quotes.md
+++ b/sample_quotes.md
@@ -1,4 +1,4 @@
 He opened the door. "Come in," she said.
 Then she whispered, "Stay\nquiet." The man nodded.
 «I won't stay long,» he replied.
-She muttered, 'you're crazy. I didn't mean that.' Then left.
+She muttered, "And so I said, 'you're crazy. I didn't mean that'. and she'd yelled back."

--- a/sample_quotes.md
+++ b/sample_quotes.md
@@ -1,0 +1,2 @@
+He opened the door. "Come in," she said.
+Then she whispered, "Stay\nquiet." The man nodded.

--- a/word_counter.rb
+++ b/word_counter.rb
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+require "lingua/stemmer"
 
 abort "usage: #{__FILE__} [markdown_file]" if ARGV.empty?
 
@@ -18,34 +19,14 @@ words = text.downcase.scan(/[a-z']+/)
 
 # Stop words to place at the end
 STOP_WORDS = %w[a an the he she it his her him their they them is am are was were be been being have has had do does did to in on at for and or but if then with by of from this i as that].freeze
-
-# Simple stemming to group different tenses
-# This is a naive approach; for full stemming use a dedicated library
-
-def stem(word)
-  w = word.downcase
-  w.gsub!(/'s$/, '')
-  return w if w.length <= 2
-
-  if w.end_with?('ing') && w.length > 5
-    w = w.sub(/ing$/, '')
-  elsif w.end_with?('ed') && w.length > 3
-    w = w.sub(/ed$/, '')
-  elsif w.end_with?('es') && w.length > 3
-    w = w.sub(/es$/, '')
-  elsif w.end_with?('s') && w.length > 3 && !w.end_with?('ss')
-    w = w.sub(/s$/, '')
-  elsif w.end_with?('e') && w.length > 3
-    w = w.sub(/e$/, '')
-  end
-  w
-end
+# Use Lingua::Stemmer for full stemming
+STEMMER = Lingua::Stemmer.new(language: "en")
 
 # Count occurrences by stem and original word
 counts = Hash.new { |h, k| h[k] = { count: 0, forms: Hash.new(0), order: nil } }
 index = 0
 words.each do |word|
-  root = stem(word)
+  root = STEMMER.stem(word)
   data = counts[root]
   data[:order] ||= index
   data[:count] += 1

--- a/word_counter.rb
+++ b/word_counter.rb
@@ -9,6 +9,7 @@ opts = Optimist.options do
   banner "usage: #{__FILE__} [options] markdown_file"
   opt :show_stopwords, "Include stop words in output", short: 's', default: false
   opt :output, "Write results to file", short: 'o', type: :string
+  opt :repeat_only, "Show only words that occur more than once", short: 'r', default: true
 end
 
 abort Optimist.educate unless ARGV.length == 1
@@ -85,6 +86,7 @@ sorted_main = main.sort_by { |e| [-e[1], e[0]] }
 sorted_stop = stop.sort_by { |e| [-e[1], e[0]] }
 
 entries = opts[:show_stopwords] ? (sorted_main + sorted_stop) : sorted_main
+entries.select! { |_, total, _| total > 1 } if opts[:repeat_only]
 
 lines = entries.map do |form_list, total, _|
   total > 1 ? "#{form_list} (#{total})" : form_list

--- a/word_counter.rb
+++ b/word_counter.rb
@@ -10,6 +10,7 @@ opts = Optimist.options do
   opt :show_stopwords, "Include stop words in output", short: 's', default: false
   opt :output, "Write results to file", short: 'o', type: :string
   opt :repeat_only, "Show only words that occur more than once", short: 'r', default: true
+  opt :keep, "Comma-separated stop words to treat as regular words", short: 'k', type: :string
 end
 
 abort Optimist.educate unless ARGV.length == 1
@@ -66,6 +67,17 @@ STOP_WORD_STEMS = STOP_WORDS_ORIG.map do |w|
   lemma = LEMMATIZER.lemma(normalized)
   Stemmer.stem_word(lemma)
 end.to_set
+
+# Remove user-specified keep words from the stop word list
+keep_stems = []
+if opts[:keep]
+  opts[:keep].split(/,\s*/).each do |kw|
+    normalized = kw.downcase.gsub(/[\u2018\u2019]/, "'")
+    lemma = LEMMATIZER.lemma(normalized)
+    keep_stems << Stemmer.stem_word(lemma)
+  end
+end
+keep_stems.each { |stem| STOP_WORD_STEMS.delete(stem) }
 
 # Count occurrences by stem and original word
 counts = Hash.new { |h, k| h[k] = { count: 0, forms: Hash.new(0), order: nil } }

--- a/word_counter.rb
+++ b/word_counter.rb
@@ -18,6 +18,9 @@ abort Optimist.educate unless ARGV.length == 1
 file = ARGV.shift
 text = File.read(file)
 
+# Remove dialogue enclosed in curly double quotes first
+text.gsub!(/“[^”]*”/m, '')
+
 # Normalize curly apostrophes so words like “couldn’t” are tokenized correctly
 text.tr!("\u2018\u2019", "'")
 # Normalize various curly and angle double quotes so dialogue can be removed

--- a/word_counter.rb
+++ b/word_counter.rb
@@ -6,6 +6,10 @@ abort "usage: #{__FILE__} [markdown_file]" if ARGV.empty?
 file = ARGV[0]
 text = File.read(file)
 
+# Normalize curly apostrophes to regular ones so words like “couldn’t”
+# are tokenized correctly
+text.gsub!(/[\u2018\u2019]/, "'")
+
 # Remove dialogue inside double quotes
 text.gsub!(/"[^"]*"/, '')
 
@@ -13,7 +17,7 @@ text.gsub!(/"[^"]*"/, '')
 words = text.downcase.scan(/[a-z']+/)
 
 # Stop words to place at the end
-STOP_WORDS = %w[a an the he she it his her him their they them is am are was were be been being have has had do does did to in on at for and or but if then with by of from].freeze
+STOP_WORDS = %w[a an the he she it his her him their they them is am are was were be been being have has had do does did to in on at for and or but if then with by of from this i as that].freeze
 
 # Simple stemming to group different tenses
 # This is a naive approach; for full stemming use a dedicated library

--- a/word_counter.rb
+++ b/word_counter.rb
@@ -1,5 +1,5 @@
 #!/usr/bin/env ruby
-require "lingua/stemmer"
+require "fast_stemmer"
 
 abort "usage: #{__FILE__} [markdown_file]" if ARGV.empty?
 
@@ -19,14 +19,13 @@ words = text.downcase.scan(/[a-z']+/)
 
 # Stop words to place at the end
 STOP_WORDS = %w[a an the he she it his her him their they them is am are was were be been being have has had do does did to in on at for and or but if then with by of from this i as that].freeze
-# Use Lingua::Stemmer for full stemming
-STEMMER = Lingua::Stemmer.new(language: "en")
+# Use fast-stemmer for full stemming
 
 # Count occurrences by stem and original word
 counts = Hash.new { |h, k| h[k] = { count: 0, forms: Hash.new(0), order: nil } }
 index = 0
 words.each do |word|
-  root = STEMMER.stem(word)
+  root = Stemmer.stem_word(word)
   data = counts[root]
   data[:order] ||= index
   data[:count] += 1

--- a/word_counter.rb
+++ b/word_counter.rb
@@ -1,0 +1,78 @@
+#!/usr/bin/env ruby
+
+abort "usage: #{__FILE__} [markdown_file]" if ARGV.empty?
+
+# Read input file
+file = ARGV[0]
+text = File.read(file)
+
+# Remove dialogue inside double quotes
+text.gsub!(/"[^"]*"/, '')
+
+# Tokenize words (letters and apostrophes only)
+words = text.downcase.scan(/[a-z']+/)
+
+# Stop words to place at the end
+STOP_WORDS = %w[a an the he she it his her him their they them is am are was were be been being have has had do does did to in on at for and or but if then with by of from].freeze
+
+# Simple stemming to group different tenses
+# This is a naive approach; for full stemming use a dedicated library
+
+def stem(word)
+  w = word.downcase
+  w.gsub!(/'s$/, '')
+  return w if w.length <= 2
+
+  if w.end_with?('ing') && w.length > 5
+    w = w.sub(/ing$/, '')
+  elsif w.end_with?('ed') && w.length > 3
+    w = w.sub(/ed$/, '')
+  elsif w.end_with?('es') && w.length > 3
+    w = w.sub(/es$/, '')
+  elsif w.end_with?('s') && w.length > 3 && !w.end_with?('ss')
+    w = w.sub(/s$/, '')
+  elsif w.end_with?('e') && w.length > 3
+    w = w.sub(/e$/, '')
+  end
+  w
+end
+
+# Count occurrences by stem and original word
+counts = Hash.new { |h, k| h[k] = { count: 0, forms: Hash.new(0), order: nil } }
+index = 0
+words.each do |word|
+  root = stem(word)
+  data = counts[root]
+  data[:order] ||= index
+  data[:count] += 1
+  data[:forms][word] += 1
+  index += 1
+end
+
+# Separate main words and stop words
+main = []
+stop = []
+counts.each do |root, data|
+  forms = data[:forms]
+  total = data[:count]
+  form_list = forms.keys.join(', ')
+  entry = [form_list, total, data[:order]]
+  if STOP_WORDS.include?(root)
+    stop << entry
+  else
+    main << entry
+  end
+end
+
+# Sort by frequency then order of appearance
+sorted_main = main.sort_by { |e| [-e[1], e[0]] }
+sorted_stop = stop.sort_by { |e| [-e[1], e[0]] }
+
+(sorted_main + sorted_stop).each do |form_list, total, _|
+  if total > 1
+    puts "#{form_list} (#{total})"
+  else
+    puts form_list
+  end
+end
+

--- a/word_counter.rb
+++ b/word_counter.rb
@@ -29,17 +29,42 @@ text.tr!("\u201C\u201D\u201E\u201F\u2033\u2036\u00AB\u00BB", '"')
 # ensure we don't strip possessives like "lucy's"
 text.gsub!(/(?<![A-Za-z])'s\b/, '')
 
-# Strip dialogue inside double quotes using a simple state machine. This works
-# more reliably on large files with uneven quoting than a single regex.
+# Strip dialogue inside double or single quotes using a quote-aware scanner.
+# Single quotes are treated as dialogue delimiters only when they look like
+# actual quotation marks rather than apostrophes in contractions.
 def strip_dialogue(text)
-  inside = false
+  # handle double-quoted dialogue first
+  inside_dq = false
   result = +''
   text.each_char do |ch|
     if ch == '"'
-      inside = !inside
-    elsif !inside
+      inside_dq = !inside_dq
+    elsif !inside_dq
       result << ch
     end
+  end
+
+  # now strip single-quoted dialogue from the intermediate result
+  text = result
+  result = +''
+  inside_sq = false
+  text.chars.each_with_index do |ch, idx|
+    if ch == "'"
+      prev = idx.zero? ? ' ' : text[idx - 1]
+      nxt  = idx + 1 >= text.length ? ' ' : text[idx + 1]
+      if inside_sq
+        if nxt =~ /\s|\p{Punct}/
+          inside_sq = false
+          next
+        end
+      else
+        if prev =~ /\s|\p{Punct}/ && nxt =~ /[A-Za-z]/
+          inside_sq = true
+          next
+        end
+      end
+    end
+    result << ch unless inside_sq
   end
   result
 end

--- a/word_counter.rb
+++ b/word_counter.rb
@@ -13,13 +13,15 @@ text = File.read(file)
 # Normalize curly apostrophes to regular ones so words like “couldn’t”
 # are tokenized correctly
 text.gsub!(/[\u2018\u2019]/, "'")
+# Normalize curly double quotes so dialogue can be removed consistently
+text.gsub!(/[\u201C\u201D]/, '"')
 
 # Remove stray "'s" fragments that can appear when apostrophes are detached but
 # ensure we don't strip possessives like "lucy's"
 text.gsub!(/(?<![A-Za-z])'s\b/, '')
 
-# Remove dialogue inside double quotes
-text.gsub!(/"[^"]*"/, '')
+# Remove dialogue inside double quotes (including normalized curly quotes)
+text.gsub!(/"[^"]*"/m, '')
 
 # Tokenize words. Allow internal apostrophes but avoid leading ones so we don't
 # end up with stray "'s" tokens.

--- a/word_counter.rb
+++ b/word_counter.rb
@@ -1,6 +1,8 @@
 #!/usr/bin/env ruby
 require "fast_stemmer"
 require "lemmatizer"
+require "stopwords"
+require "set"
 
 abort "usage: #{__FILE__} [markdown_file]" if ARGV.empty?
 
@@ -23,8 +25,8 @@ text.gsub!(/"[^"]*"/, '')
 # end up with stray "'s" tokens.
 words = text.downcase.scan(/[a-z]+(?:'[a-z]+)*/)
 
-# Stop words to place at the end
-STOP_WORDS = %w[a an the he she it his her him their they them is am are was were be been being have has had do does did to in on at for and or but if then with by of from this i as that].freeze
+# Stop words to place at the end using the built-in list from the stopwords gem
+STOP_WORDS = Stopwords::STOP_WORDS.to_set
 # Use fast-stemmer for full stemming and Lemmatizer for irregular forms
 LEMMATIZER = Lemmatizer.new
 

--- a/word_counter.rb
+++ b/word_counter.rb
@@ -28,7 +28,9 @@ text.gsub!(/"[^"]*"/m, '')
 words = text.downcase.scan(/[a-z]+(?:'[a-z]+)*/)
 
 # Stop words to place at the end using the built-in list from the stopwords gem
-STOP_WORDS = Stopwords::STOP_WORDS.to_set
+# plus a few common contractions and auxiliary verbs that are not included
+# in that list.
+STOP_WORDS = Stopwords::STOP_WORDS.to_set.merge(%w[did didn't couldn't])
 # Use fast-stemmer for full stemming and Lemmatizer for irregular forms
 LEMMATIZER = Lemmatizer.new
 
@@ -36,6 +38,8 @@ LEMMATIZER = Lemmatizer.new
 counts = Hash.new { |h, k| h[k] = { count: 0, forms: Hash.new(0), order: nil } }
 index = 0
 words.each do |word|
+  # Remove trailing possessive 's so "lucy's" and "lucy" are grouped together
+  word = word.sub(/'s$/, '')
   # Normalize irregular forms using the lemmatizer then stem
   lemma = LEMMATIZER.lemma(word)
   root = Stemmer.stem_word(lemma)

--- a/word_counter.rb
+++ b/word_counter.rb
@@ -96,8 +96,8 @@ counts.each do |root, data|
 end
 
 # Sort by frequency then order of appearance
-sorted_main = main.sort_by { |e| [-e[1], e[0]] }
-sorted_stop = stop.sort_by { |e| [-e[1], e[0]] }
+sorted_main = main.sort_by { |form_list, total, order| [-total, order] }
+sorted_stop = stop.sort_by { |form_list, total, order| [-total, order] }
 
 entries = opts[:show_stopwords] ? (sorted_main + sorted_stop) : sorted_main
 entries.select! { |_, total, _| total > 1 } if opts[:repeat_only]

--- a/word_counter.rb
+++ b/word_counter.rb
@@ -29,11 +29,8 @@ text.tr!("\u201C\u201D\u201E\u201F\u2033\u2036\u00AB\u00BB", '"')
 # ensure we don't strip possessives like "lucy's"
 text.gsub!(/(?<![A-Za-z])'s\b/, '')
 
-# Strip dialogue inside double or single quotes using a quote-aware scanner.
-# Single quotes are treated as dialogue delimiters only when they look like
-# actual quotation marks rather than apostrophes in contractions.
+# Strip dialogue enclosed in double quotes using a quote-aware scanner.
 def strip_dialogue(text)
-  # handle double-quoted dialogue first
   inside_dq = false
   result = +''
   text.each_char do |ch|
@@ -42,29 +39,6 @@ def strip_dialogue(text)
     elsif !inside_dq
       result << ch
     end
-  end
-
-  # now strip single-quoted dialogue from the intermediate result
-  text = result
-  result = +''
-  inside_sq = false
-  text.chars.each_with_index do |ch, idx|
-    if ch == "'"
-      prev = idx.zero? ? ' ' : text[idx - 1]
-      nxt  = idx + 1 >= text.length ? ' ' : text[idx + 1]
-      if inside_sq
-        if nxt =~ /\s|\p{Punct}/
-          inside_sq = false
-          next
-        end
-      else
-        if prev =~ /\s|\p{Punct}/ && nxt =~ /[A-Za-z]/
-          inside_sq = true
-          next
-        end
-      end
-    end
-    result << ch unless inside_sq
   end
   result
 end

--- a/word_counter.rb
+++ b/word_counter.rb
@@ -20,8 +20,10 @@ text = File.read(file)
 
 # Normalize curly apostrophes so words like “couldn’t” are tokenized correctly
 text.tr!("\u2018\u2019", "'")
-# Normalize various curly double quotes so dialogue can be removed consistently
-text.tr!("\u201C\u201D\u201E\u201F\u2033\u2036", '"')
+# Normalize various curly and angle double quotes so dialogue can be removed
+# consistently.  This helps drop text quoted with less common punctuation such
+# as «like this».
+text.tr!("\u201C\u201D\u201E\u201F\u2033\u2036\u00AB\u00BB", '"')
 
 # Remove stray "'s" fragments that can appear when apostrophes are detached but
 # ensure we don't strip possessives like "lucy's"

--- a/word_counter.yml
+++ b/word_counter.yml
@@ -1,0 +1,2 @@
+keep_stop_words:
+  - still


### PR DESCRIPTION
## Summary
- add `word_counter.rb` to count recurring words in a document while ignoring dialog

## Testing
- `ruby -wc word_counter.rb`
- `./word_counter.rb sample.md`

------
https://chatgpt.com/codex/tasks/task_e_68634a5833e88333b5074e04087a638d