### PR TITLE
Ignore headers and underlined text in word counter

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,11 +36,12 @@ keep_stop_words:
 
 The script loads this configuration automatically if the file exists.
 
- The script strips dialogue before counting words. It first removes text
- enclosed in curly double quotes (`“...”`) and then runs a quote-aware scanner
- to drop any remaining straight or angle double quoted passages. See
- `sample_quotes.md` for examples including single-quoted, angle-quoted, and
- curly-quoted dialogue.
+It removes Markdown headers (lines starting with `##`) and any text enclosed in
+underscores before counting words. The script also strips dialogue. It first
+removes text enclosed in curly double quotes (`“...”`) and then runs a
+quote-aware scanner to drop any remaining straight or angle double quoted
+passages. See `sample_quotes.md` for examples including single-quoted,
+angle-quoted, and curly-quoted dialogue.
 Trailing possessive `'s` is collapsed so words like `Lucy` and `Lucy's` are
 tallied together. Extra stop words like `this`, `i`, `as`, `that`, `his`,
 `they`, `did`, `could`, `didn't`, and `couldn't` are merged with the gem's

--- a/word_counter.rb
+++ b/word_counter.rb
@@ -19,7 +19,11 @@ abort Optimist.educate unless ARGV.length == 1
 file = ARGV.shift
 text = File.read(file)
 
-# Remove dialogue enclosed in curly double quotes first
+# Remove Markdown headers and underlined text
+text.gsub!(/^##.*\n?/, '')
+text.gsub!(/_[^_]*_/, '')
+
+# Remove dialogue enclosed in curly double quotes
 text.gsub!(/“[^”]*”/m, '')
 
 # Normalize curly apostrophes so words like “couldn’t” are tokenized correctly


### PR DESCRIPTION
## Summary
- Skip Markdown headers (`##`) and underlined passages before counting words
- Document header and underline stripping alongside existing dialogue filtering

## Testing
- `ruby -c word_counter.rb`
- `ruby word_counter.rb sample.md`


------
https://chatgpt.com/codex/tasks/task_e_689bf6e8903483339325f8f9fdd79d3c